### PR TITLE
Build Gtest instead of installing using package manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,5 +29,18 @@ enable_testing()
 
 option(BUILD_TESTS "Build all tests" OFF)
 if (BUILD_TESTS)
+
+include(FetchContent)
+    FetchContent_Declare(
+    googletest
+    URL 
+    https://github.com/google/googletest/archive/refs/tags/release-1.10.0.zip
+    )
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+
+    include(GoogleTest)
+
     add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ enable_testing()
 option(BUILD_TESTS "Build all tests" OFF)
 if (BUILD_TESTS)
 
-include(FetchContent)
+    include(FetchContent)
     FetchContent_Declare(
     googletest
     URL 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@
 cmake_minimum_required(VERSION 3.10)
 find_package(OpenCV REQUIRED)
 find_package(GTest REQUIRED)
+enable_testing()
 
 # finds all .cpp files under this directory (./test) and add them to executable
 file(GLOB_RECURSE tests "*.cpp")
@@ -14,9 +15,13 @@ include_directories("../3rdparty/libwebp/include")
 # Link gtest libraries
 target_link_libraries(splitwebp_tests ${OpenCV_LIBS})
 target_link_libraries(splitwebp_tests webp webpdemux pthread)
-target_link_libraries(splitwebp_tests GTest::GTest GTest::Main)
+# target_link_libraries(splitwebp_tests GTest::GTest GTest::Main)
+
+target_link_libraries(splitwebp_tests gtest_main)
 
 set(CTEST_OUTPUT_ON_FAILURE 1)
 
 # Find all tests in all .cpp files and convert to CTests
+include(GoogleTest)
+
 gtest_discover_tests(splitwebp_tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Requiring V 3.10 for gtest_discover_tests
 cmake_minimum_required(VERSION 3.10)
 find_package(OpenCV REQUIRED)
-find_package(GTest REQUIRED)
 enable_testing()
 
 # finds all .cpp files under this directory (./test) and add them to executable
@@ -15,8 +14,6 @@ include_directories("../3rdparty/libwebp/include")
 # Link gtest libraries
 target_link_libraries(splitwebp_tests ${OpenCV_LIBS})
 target_link_libraries(splitwebp_tests webp webpdemux pthread)
-# target_link_libraries(splitwebp_tests GTest::GTest GTest::Main)
-
 target_link_libraries(splitwebp_tests gtest_main)
 
 set(CTEST_OUTPUT_ON_FAILURE 1)


### PR DESCRIPTION
Having separate `google test` for different projects is a good practice